### PR TITLE
added error handling for restarted mqtt broker

### DIFF
--- a/EvnSmartmeterMQTTKaifaMA309.py
+++ b/EvnSmartmeterMQTTKaifaMA309.py
@@ -126,6 +126,15 @@ while 1:
 
     #MQTT
     if useMQTT:
+        connected = False
+        while not connected:
+            try:
+                client.reconnect()
+                connected = True
+            except:
+                print("Lost Connection to MQTT...Trying to reconnect in 2 Seconds")
+                time.sleep(2)
+
         client.publish("Smartmeter/WirkenergieP", WirkenergieP)
         client.publish("Smartmeter/WirkenergieN", WirkenergieN)
         client.publish("Smartmeter/MomentanleistungP", MomentanleistungP)


### PR DESCRIPTION
The MQTT library won't automatically reconnect, if the connection to the mqtt broker is lost.
This small loop will try to reconnect every 2 seconds until the broker comes online again.