### PR TITLE
Lxml Fehler verhindern

### DIFF
--- a/EvnSmartmeterMQTTKaifaMA309.py
+++ b/EvnSmartmeterMQTTKaifaMA309.py
@@ -62,7 +62,7 @@ while 1:
         pdu.clear()
         xml += tr.messageToXml(msg)
 
-    soup = BeautifulSoup(xml, 'lxml')
+    soup = BeautifulSoup(xml, "html5lib")
 
     results_32 = soup.find_all('uint32')
     results_16 = soup.find_all('uint16')


### PR DESCRIPTION
Es gibt den Fehler:
`bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml` (https://github.com/greenMikeEU/SmartMeterEVNKaifaMA309/issues/7)

einfach 2. argument zu html5lib setzen und fertig